### PR TITLE
Add updater and index. 

### DIFF
--- a/index.lua
+++ b/index.lua
@@ -32,8 +32,8 @@ local BMOS = {
 		"trampoline.lua",
 	},
 	"index.lua",
-	"install.lua",
 	"README.md",
+	"update.lua",
 }
 
 return BMOS, PATH

--- a/index.lua
+++ b/index.lua
@@ -2,7 +2,7 @@
 
 local arg = {...}
 if arg[2] then 
-	arg[2] = "/tree/v"..arg[2]
+	arg[2] = "/tree/"..arg[2]
 else
 	arg[2] = ""
 end

--- a/index.lua
+++ b/index.lua
@@ -2,7 +2,7 @@
 
 local arg = {...}
 if arg[2] then 
-	arg[2] = "/tree/v"
+	arg[2] = "/tree/v"..arg[2]
 else
 	arg[2] = ""
 end

--- a/index.lua
+++ b/index.lua
@@ -1,13 +1,5 @@
 --File index 
 
-local arg = {...}
-if arg[2] then 
-	arg[2] = "/tree/"..arg[2]
-else
-	arg[2] = ""
-end
-local PATH = "Tankobot/BMOS/"..arg[1]..arg[2]
-
 local BMOS = {
 	data = {
 		startup = {
@@ -34,6 +26,7 @@ local BMOS = {
 	"index.lua",
 	"README.md",
 	"update.lua",
+	"end",
 }
 
 return BMOS, PATH

--- a/index.lua
+++ b/index.lua
@@ -1,0 +1,39 @@
+--File index 
+
+local arg = {...}
+if arg[2] then 
+	arg[2] = "/tree/v"
+else
+	arg[2] = ""
+end
+local PATH = "Tankobot/BMOS/"..arg[1]..arg[2]
+
+local BMOS = {
+	data = {
+		startup = {
+			"main.lua",
+		},
+	},
+	lib = {
+		os = {
+			"argSorter.lua",
+			"codec.lua",
+			"gui.lua",
+			"net.lua",
+			"task.lua",
+		},
+	},
+	tools = {
+		"CCIedit.lua",
+		"login.lua",
+		"startup",
+		"sudo.lua",
+		"taskManager",
+		"trampoline.lua",
+	},
+	"index.lua",
+	"install.lua",
+	"README.md",
+}
+
+return BMOS, PATH

--- a/index.lua
+++ b/index.lua
@@ -29,4 +29,4 @@ local BMOS = {
 	"end",
 }
 
-return BMOS, PATH
+return BMOS

--- a/update.lua
+++ b/update.lua
@@ -7,18 +7,41 @@ local _NAME = "Tankobot/BMOS/"
 local _PATH = "https://raw.githubusercontent.com/".._NAME
 local download
 local arg = {...}
+local place
+local names = {}
 
 assert(http, "The updater requires the 'http' api in order to download necessary files.")
 
-local function download(dirTable, currentPath)
+local function download(dirTable, currentPath, statName)
 	for i, v in pairs(dirTable) do
 		if type(v) == "table" then
-			local status, message = download(v, currentPath..v.."/"
+			local status, message = pcall(download, v, currentPath..i.."/")
+			if not status then
+				error(message, 0)
+			else
+				return message
+			end
 		elseif type(v) == "string" then
-			http.request("https://raw.githubusercontent.com/"..
-			"Tankobot/BMOS/"..arg[1]..currentPath)
+			if v == "end" then
+				return true
+			else
+				place = _PATH..arg[1]..currentPath
+				http.request(place)
+				names[place] = currentPath..v
+			end
 		else
 			error("Index formatted incorrectly, expected 'table' or 'string'. Got "..type(v), 0)
+		end
+	end
+end
+
+local function http2drive(path, names)
+	while true do
+		local event = {os.pullEvent()}
+		if event[1] == "http_success" then
+			--TODO
+		elseif event[1] == "http_failure" then
+			print("Failed to download file at '"..names[event[2]].."'.")
 		end
 	end
 end

--- a/update.lua
+++ b/update.lua
@@ -12,20 +12,20 @@ local names = {}
 
 assert(http, "The updater requires the 'http' api in order to download necessary files.")
 
-local function download(dirTable, currentPath, statName)
+local function download(dirTable, currentPath)
+	if not dirTable then dirTable = {} end
 	for i, v in pairs(dirTable) do
 		if type(v) == "table" then
 			local status, message = pcall(download, v, currentPath..i.."/")
 			if not status then
 				error(message, 0)
-			else
-				return message
 			end
 		elseif type(v) == "string" then
 			if v == "end" then
+				os.queueEvent("end")
 				return true
 			else
-				place = _PATH..arg[1]..currentPath
+				place = _PATH..arg[1]..currentPath..v
 				http.request(place)
 				names[place] = currentPath..v
 			end
@@ -39,9 +39,23 @@ local function http2drive(path, names)
 	while true do
 		local event = {os.pullEvent()}
 		if event[1] == "http_success" then
-			--TODO
+			local file = io.open(names[event[2]], "w")
+			file:write(event[3]:readAll())
+			file:close()
 		elseif event[1] == "http_failure" then
 			print("Failed to download file at '"..names[event[2]].."'.")
+		elseif event[1] == "end" then
+			return
 		end
 	end
 end
+
+local BMOS = loadfile("index.lua")()
+
+if not arg[2] then arg[2] = shell.dir() end
+
+download(BMOS, "") 
+http2drive(arg[2], names)
+
+print("BMOS finished downloading.")
+print("Check above for errors. If no errors exist, BMOS should have installed correctly.")

--- a/update.lua
+++ b/update.lua
@@ -10,6 +10,10 @@ local arg = {...}
 local place
 local names = {}
 
+print("Retrieving index for requested version of BMOS, or master branch.")
+assert(http.get(_PATH..arg[1].."/index.lua"), "Failed to retrieve index for "..arg[1]..".")
+print("Retrieved index for "..arg[1]..".")
+
 assert(http, "The updater requires the 'http' api in order to download necessary files.")
 
 local function download(dirTable, currentPath)

--- a/update.lua
+++ b/update.lua
@@ -2,3 +2,23 @@
 Title: BMOS Updater
 Version: v0.1
 --]] 
+
+local _NAME = "Tankobot/BMOS/"
+local _PATH = "https://raw.githubusercontent.com/".._NAME
+local download
+local arg = {...}
+
+assert(http, "The updater requires the 'http' api in order to download necessary files.")
+
+local function download(dirTable, currentPath)
+	for i, v in pairs(dirTable) do
+		if type(v) == "table" then
+			local status, message = download(v, currentPath..v.."/"
+		elseif type(v) == "string" then
+			http.request("https://raw.githubusercontent.com/"..
+			"Tankobot/BMOS/"..arg[1]..currentPath)
+		else
+			error("Index formatted incorrectly, expected 'table' or 'string'. Got "..type(v), 0)
+		end
+	end
+end

--- a/update.lua
+++ b/update.lua
@@ -1,0 +1,4 @@
+--[[
+Title: BMOS Updater
+Version: v0.1
+--]] 


### PR DESCRIPTION
We are ushering in a new era of ease of install for BMOS. Now you must only download the installer, and enable the http api. Run the installer with specified version and path of install, and it'll do the rest. 

_Usage: install.lua [version] [path]_

Version will default to master branch if left blank, and path will default to the root directory. 
